### PR TITLE
remove unused "#include <THC/THC.h>"  that caused troubles with new versions of CUDA

### DIFF
--- a/models/PointUtils/src/furthest_point_sampling.cpp
+++ b/models/PointUtils/src/furthest_point_sampling.cpp
@@ -1,7 +1,7 @@
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
 
 #include "furthest_point_sampling_gpu.h"
 


### PR DESCRIPTION
New versions of CUDA do not have this header file, which creates problems when installing PointUtils. Without this line everything works fine.